### PR TITLE
Use the colors defined in the last style.css of add-on template

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,8 +1,6 @@
 ﻿@charset "utf-8";
 body { 
 font-family : Verdana, Arial, Helvetica, Sans-serif;
-color : #FFFFFF;
-background-color : #000000;
 line-height: 1.2em;
 } 
 h1, h2 {text-align: center}
@@ -26,5 +24,3 @@ a { text-decoration : underline;
 text-decoration : none; 
 }
 a:focus, a:hover {outline: solid}
-:link {color: #0000FF;
-background-color: #FFFFFF}


### PR DESCRIPTION
### Issue
The color theme of the help page is with light text on dark background, which is less common. When visually impaired people (such as myself) use high contrast customization with inverted colors, the text becomes dark on a light background, which is not suitable.

### Solution
Used the style scheme introduced in add-on template for a long time now (sse https://github.com/nvdaaddons/AddonTemplate/pull/8).

### Test
Visually checked the colors.
