### PR TITLE
Support more scriptable objects

### DIFF
--- a/addon/globalPlugins/commandHelper/__init__.py
+++ b/addon/globalPlugins/commandHelper/__init__.py
@@ -432,11 +432,14 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 					return
 	
 			# Braille display
+			import globalVars as gv
+			gv.dbg = commandInfo
 			if not script and issubclass(commandInfo.cls, braille.BrailleDisplayDriver):
 				try:
 					script = getattr(braille.handler.display, "script_" + commandInfo.scriptName)
 				except AttributeError:
-					pass
+					menuMessage(_("Can't run this script while the corresponding braille driver is not active"))
+					return
 	
 			# Vision enhancement provider
 			if not script and issubclass(commandInfo.cls, vision.providerBase.VisionEnhancementProvider):


### PR DESCRIPTION
### Link to issue
Closes #11

### Issue

Some scripts cannot be run by the add-on:
* scripts from Global plugins in complex add-ons, e.g. in NVDA Dev & Test Toolbox, where the main `GlobalPlugin` inherits from many other `GlobalPlugin`'s which actually contain the scripts
* Scripts created in Emulated key category
* Scripts associated to ancestors of the focused object, e.g. in Column Review add-on (see Tests section)
* Scripts associated to tree inteceptor, e.g. quick navigation keys.
* Scripts associated to braille display drivers
* Scripts associated to vision providers (do not exist natively in NVDA for now)

### Solution

Generalized the implementation of the add-on.
Thus, I have removed the specific check for NVDA global commands extension; please double check that all is OK.

I have also had to move the `self.finish()` code line to be able to execute emulated keys scripts.

### Tests

Tested the following types of scripts:
- key emulation: created a custom gesture to emulate control+A
- global plugin script: NVDA Dev & Test Toolbox command to log the stack (NVDA+control+alt+s)
- app module script: with poedit command to read translators notes (control+shift+A), both in poedit (normal behaviour) and in Notepad (error message)
- braille display script: Created a dummy scriptable braille driver based on the "no braille" driver, with a test script in it. And tested that my script can be called with this add-on when the driver is selected and that the rror message is reported when another driver is selected.
- vision provider script: created a dedicated test script in Focus Highlighter provider, both when vision highlight is on (normal behaviour) and off (error message)
- tree interceptor: with "move to the next heading" sscript (H), both in Word and Chrome, both in browse and focus mode, and in Notepad (error message)
- NVDAObject (focus) script: Read comment in Word document (NVDA+alt+C)
- focus ancestor script: Column Review add-on, in Explorer file list, command to fin an item (NVDA+control+F). 
- profile activation script: tested with a manually created provile
- Global command script tested with "Reports the title of the current application or foreground window" (NVDA+T)

For focus and focus ancestor, we do not test previously that the class is NVDAObject, because it caused issues with cursor manager scripts (e.g. find); thus, there is no specific error messages for these categories.

Tested that double and triple press still works (after code move).

Tested two or three commands from NVDA global commands extension add-on. Feel free to test more of them in case there are specific corner cases with this add-on that I would not have captured.
