### PR TITLE
Fix up #13 (Radio center add-on support)

### DIFF
--- a/addon/globalPlugins/commandHelper/__init__.py
+++ b/addon/globalPlugins/commandHelper/__init__.py
@@ -418,9 +418,11 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			if not script and issubclass(commandInfo.cls, globalPluginHandler.GlobalPlugin):
 				pluginPath = '.'.join(commandInfo.moduleName.split(".")[:2])
 				for m in globalPluginHandler.runningPlugins:
-					if m.__module__ == pluginPath:
+					if isinstance(m, commandInfo.cls):
 						plugin = m
 						break
+				else:
+					raise RuntimeError(f"Failed to retrieve scripts for '{commandInfo.className}'. Not found in global plugins.")
 				script = getattr(plugin, "script_"+commandInfo.scriptName)
 
 			# App module
@@ -432,8 +434,6 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 					return
 	
 			# Braille display
-			import globalVars as gv
-			gv.dbg = commandInfo
 			if not script and issubclass(commandInfo.cls, braille.BrailleDisplayDriver):
 				try:
 					script = getattr(braille.handler.display, "script_" + commandInfo.scriptName)
@@ -444,7 +444,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			# Vision enhancement provider
 			if not script and issubclass(commandInfo.cls, vision.providerBase.VisionEnhancementProvider):
 				for provider in vision.handler.getActiveProviderInstances():
-					if isinstance(provider, baseObject.ScriptableObject):
+					if isinstance(provider, commandInfo.cls):
 						script = getattr(provider, "script_"+commandInfo.scriptName, None)
 						if script:
 							break


### PR DESCRIPTION
Fixing an issue reported by @blindhelp (Rémy Ruiz). Thanks for having reported!

### Issue
The scripts of Radio Center add-on cannot be run through the virtual menu.

It's because command helper should be able to run any global plugin, no matter its location.

### Solution
Check the class rather than its location.

While at it, I have removed some debug code left over from #13.

### Tests
Re-tested:
* Scripts from complex global plugins such as Radio Center, NVDA Dev & Test Toolbox and NVDA Global command extension.
* Vision provider script
